### PR TITLE
fix: wrong case on lodash.clonedeep method

### DIFF
--- a/modules/zero-components/button/plugins/button.js
+++ b/modules/zero-components/button/plugins/button.js
@@ -1,6 +1,6 @@
 // ///////////////////////////////////////////////////////////////////// Imports
 // -----------------------------------------------------------------------------
-import CloneDeep from 'lodash.cloneDeep'
+import CloneDeep from 'lodash.clonedeep'
 import { defineNuxtPlugin } from '#imports'
 import { useZeroButtonStore } from '../stores/button.js'
 


### PR DESCRIPTION
Minor case sensitivity fix on one of the methods, continuation from #6


## Ticket link
🎟️ [AU-2918](https://www.notion.so/agencyundone/Devops-codebase-structure-and-CI-35467d589528465eaec30841ff322ed6?pvs=4) (internal ticket)