### PR TITLE
feat: compile site metadata

### DIFF
--- a/components/site-footer.vue
+++ b/components/site-footer.vue
@@ -13,7 +13,7 @@
         </div>
 
         <div class="col-4_sm-5_mi-7" data-push-left="off-6_sm-2_mi-0">
-          <div class="authors">
+          <div v-if="authors" class="authors">
             <div
               class="text"
               v-html="authors.text">
@@ -40,7 +40,7 @@
         </div>
 
         <div class="col-4_md-5_sm-12">
-          <div class="legal">
+          <div v-if="legal" class="legal">
             <ZeroButton
               v-for="link in legal.links"
               :key="link.text"
@@ -59,16 +59,16 @@
 </template>
 
 <script setup>
-// ===================================================================== Imports
-import GeneralSiteData from '@/content/core/general.json'
+// ======================================================================== Data
+const generalStore = useGeneralStore()
 
 // ==================================================================== Computed
 const authors = computed(() => {
-  return GeneralSiteData.footer.authors
+  return generalStore.siteContent.general?.footer.authors
 })
 
 const legal = computed(() => {
-  return GeneralSiteData.footer.legal
+  return generalStore.siteContent.general?.footer.legal
 })
 
 const scrollToTop = async () => {

--- a/content/core/general.json
+++ b/content/core/general.json
@@ -7,7 +7,7 @@
     "site_name": "Singularity",
     "url": "https://singularity.storage",
     "type": "website",
-    "image": "/images/singularity-open-graph.jpg"
+    "image": "images/singularity-open-graph.jpg"
   },
   "header": {
     "navigation": [

--- a/content/core/index.json
+++ b/content/core/index.json
@@ -7,7 +7,7 @@
     "site_name": "Singularity",
     "url": "https://singularity.storage",
     "type": "website",
-    "image": "/images/singularity-open-graph.jpg"
+    "image": "images/singularity-open-graph.jpg"
   },
   "page_content": [
     {

--- a/content/core/signup.json
+++ b/content/core/signup.json
@@ -7,7 +7,7 @@
     "site_name": "Singularity",
     "url": "",
     "type": "website",
-    "image": "/images/open-graph.png"
+    "image": "images/singularity-open-graph.jpg"
   },
   "page_content": [
     {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,8 +4,8 @@ const env = process.env.SERVER_ENV
 
 const baseUrls = {
   development: 'https://localhost',
-  stable: '',
-  production: ''
+  stable: 'https://singularity-website.on.fleek.co/',
+  production: 'https://singularity.storage/'
 }
 
 const frontendPort = 10050

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,15 +10,23 @@
 import BlockBuilder from '@/components/blocks/block-builder'
 
 // ======================================================================== Data
+const generalStore = useGeneralStore()
 const route = useRoute()
+const { $GetSeo, $CompileSeo } = useNuxtApp()
 const { data } = await useAsyncData('core', async () => {
   return queryContent('core').find()
 })
 
+// ==================================================================== Watchers
+watch(data, async (val) => {
+  await generalStore.getBaseData('general')
+  await generalStore.getBaseData({ key: 'index', data: val.find((item) => item._file === 'core/index.json') })
+  useHead($CompileSeo($GetSeo('general', 'index')))
+}, { immediate: true })
+
 // ==================================================================== Computed
 const sections = computed(() => {
-  const index = data._rawValue.find((item) => item._file === 'core/index.json')
-  return index.page_content
+  return generalStore.siteContent?.index?.page_content
 })
 
 // ==================================================================== On Mount
@@ -32,6 +40,10 @@ onMounted(() => {
       }
     }
   }, 1)
+})
+
+onBeforeUnmount(() => {
+  generalStore.clearStore()
 })
 
 </script>

--- a/plugins/compile-seo.js
+++ b/plugins/compile-seo.js
@@ -1,0 +1,60 @@
+/*
+ *
+ * 🔌 [Plugin] CompileSeo
+ *
+ */
+
+// ///////////////////////////////////////////////// Convert SEO to final output
+// ------------------------------------------------------ Output for head() hook
+export default defineNuxtPlugin(nuxtApp => {
+  const config = useRuntimeConfig()
+  nuxtApp.provide('CompileSeo', (seo) => {
+    const siteName = config.public.seo.siteName
+    const siteUrl = config.public.siteUrl
+    const title = seo.title
+    const description = seo.description
+    const image = siteUrl + seo.og_image
+    const url = seo.og_url
+    const incomingStructuredData = seo.structured_data || {}
+    const structuredData = {
+      '@context': 'https://schema.org',
+      '@type': incomingStructuredData['@type'] || 'WebSite',
+      name: title,
+      abstract: description,
+      mainEntity: {
+        '@type': incomingStructuredData['@type'] || 'WebSite',
+        name: siteName,
+        url: siteUrl
+      },
+      image,
+      url
+    }
+    return {
+      title,
+      meta: [
+        {
+          hid: 'description',
+          name: 'description',
+          content: description
+        },
+        { hid: 'og:title', property: 'og:title', content: title },
+        { hid: 'og:description', property: 'og:description', content: description },
+        { hid: 'og:site_name', property: 'og:site_name', content: seo.og_site_name },
+        { hid: 'og:url', property: 'og:url', content: url },
+        { hid: 'og:type', property: 'og:type', content: seo.og_type },
+        { hid: 'og:image', property: 'og:image', content: image },
+        { hid: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
+        { hid: 'twitter:title', name: 'twitter:title', content: title },
+        { hid: 'twitter:description', name: 'twitter:description', content: description },
+        { hid: 'twitter:image', name: 'twitter:image', content: image }
+      ],
+      link: [
+        { rel: 'canonical', href: url },
+        { rel: 'alternate', hreflang: 'en', href: url },
+        { rel: 'alternate', hreflang: 'x-default', href: url }
+      ],
+      __dangerouslyDisableSanitizers: ['script'],
+      script: [{ innerHTML: JSON.stringify(structuredData), type: 'application/ld+json' }]
+    }
+  })
+})

--- a/plugins/get-seo.js
+++ b/plugins/get-seo.js
@@ -1,0 +1,29 @@
+/*
+ *
+ * 🔌 [Plugin] GetSeo
+ *
+ */
+
+// ///////////////////////////////////////////////// Get SEO and Open Graph data
+// ----------------------------- Return global SEO if no identifier is specified
+export default defineNuxtPlugin(nuxtApp => {
+  nuxtApp.provide('GetSeo', (storeName = 'general', identifier = 'general') => {
+    const store = nuxtApp.$pinia.state.value[storeName]
+    let data = store.siteContent[identifier]
+    if (!data) { data = store.siteContent.general }
+    if (data) {
+      const seo = data.seo
+      const og = data.og
+      return {
+        title: seo.title,
+        description: seo.description,
+        structured_data: seo.structured_data,
+        og_site_name: og.site_name,
+        og_url: og.url,
+        og_type: og.type,
+        og_image: og.image
+      }
+    }
+    return {}
+  })
+})

--- a/stores/general.js
+++ b/stores/general.js
@@ -1,7 +1,7 @@
 // ///////////////////////////////////////////////////////////////////// Imports
 // -----------------------------------------------------------------------------
 import { ref } from '#imports'
-// import GeneralSiteData from '@/content/core/general.json'
+import GeneralSiteData from '@/content/core/general.json'
 
 // /////////////////////////////////////////////////////////////////////// State
 // -----------------------------------------------------------------------------
@@ -18,18 +18,17 @@ const clearStore = () => {
 }
 
 // /////////////////////////////////////////////////////////////// getBaseData
-// const getBaseData = async (payload) => {
-//   const key = typeof payload === 'string' ? payload : payload.key
-//   let data = false
-//   switch (key) {
-//     case 'general': data = GeneralSiteData; break
-//     default : data = payload.data; break
-//   }
-//   if (data) {
-//     siteContent.value[key] = data
-//     console.log(siteContent)
-//   }
-// }
+const getBaseData = async (payload) => {
+  const key = typeof payload === 'string' ? payload : payload.key
+  let data = false
+  switch (key) {
+    case 'general': data = GeneralSiteData; break
+    default : data = payload.data; break
+  }
+  if (data) {
+    siteContent.value[key] = data
+  }
+}
 
 // //////////////////////////////////////////////////////////////////// setTheme
 const setTheme = (newTheme) => {
@@ -53,7 +52,7 @@ export const useGeneralStore = defineStore('general', () => ({
   navigationOpen,
   // ----- actions
   clearStore,
-  // getBaseData,
+  getBaseData,
   setTheme,
   setNavigationOpen
 }))


### PR DESCRIPTION
This PR adds two plugins to help compile SEO and site metadata which is passed to the Nuxt 3 native composable `useHead()` which adds this data to the html document head tag. 

The two plugins `get-seo.js` and `compile-seo.js` have been copied from our Nuxt 2 boilerplate with only slight adjustments to accommodate a new store structure with the Pinia store and the config object in Nuxt 3. A wrapping function around each has also been included as Nuxt 3 needs this in order to properly inject the functions into the app scope.

Also site content is now added to the store once fetched with the `useAsyncData` composable and from there is used throughout the app rather than accessing data directly from imported json objects. 

## Ticket link
https://www.notion.so/agencyundone/Open-graph-and-metadata-via-Nuxt-3-00cba4168fa2487fae3efe1f001b3563?pvs=4
