### PR TITLE
fix: disable svgs on fonts

### DIFF
--- a/assets/scss/theme/typography.scss
+++ b/assets/scss/theme/typography.scss
@@ -15,8 +15,8 @@ $fontAssetPath: 'assets/fonts';
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.eot');
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.eot?#iefix') format('embedded-opentype'),
     url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.woff2') format('woff2'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.otf') format('opentype'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.svg#SuisseIntl-Light') format('svg');
+    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.otf') format('opentype');
+    // url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Light.svg#SuisseIntl-Light') format('svg');
   font-weight: 300;
   font-style: normal;
 }
@@ -26,8 +26,8 @@ $fontAssetPath: 'assets/fonts';
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.eot');
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.eot?#iefix') format('embedded-opentype'),
     url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.woff2') format('woff2'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.otf') format('opentype'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.svg#SuisseIntl-Regular') format('svg');
+    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.otf') format('opentype');
+    // url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Regular.svg#SuisseIntl-Regular') format('svg');
   font-weight: 400;
   font-style: normal;
 }
@@ -44,8 +44,8 @@ $fontAssetPath: 'assets/fonts';
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.eot');
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.eot?#iefix') format('embedded-opentype'),
     url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.woff2') format('woff2'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.otf') format('opentype'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.svg#SuisseIntl-Medium') format('svg');
+    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.otf') format('opentype');
+    // url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Medium.svg#SuisseIntl-Medium') format('svg');
   font-weight: 500;
   font-style: normal;
 }
@@ -62,8 +62,8 @@ $fontAssetPath: 'assets/fonts';
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.eot');
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.eot?#iefix') format('embedded-opentype'),
     url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.woff2') format('woff2'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.otf') format('opentype'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.svg#SuisseIntl-SemiBold') format('svg');
+    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.otf') format('opentype');
+    // url('#{$fontAssetPath}/suisse-intl/SuisseIntl-SemiBold.svg#SuisseIntl-SemiBold') format('svg');
   font-weight: 600;
   font-style: normal;
 }
@@ -73,8 +73,8 @@ $fontAssetPath: 'assets/fonts';
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.eot');
   src: url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.eot?#iefix') format('embedded-opentype'),
     url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.woff2') format('woff2'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.otf') format('opentype'),
-    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.svg#SuisseIntl-Bold') format('svg');
+    url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.otf') format('opentype');
+    // url('#{$fontAssetPath}/suisse-intl/SuisseIntl-Bold.svg#SuisseIntl-Bold') format('svg');
   font-weight: 700;
   font-style: normal;
 }
@@ -85,8 +85,8 @@ $fontAssetPath: 'assets/fonts';
   src: url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.eot');
   src: url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.eot?#iefix') format('embedded-opentype'),
     url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.woff2') format('woff2'),
-    url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.otf') format('opentype'),
-    url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.svg#Suisse-Intl-Mono-Regular') format('svg');
+    url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.otf') format('opentype');
+    // url('#{$fontAssetPath}/suisse-intl-mono/SuisseIntlMono-Regular.svg#Suisse-Intl-Mono-Regular') format('svg');
   font-weight: 400;
   font-style: normal;
 }


### PR DESCRIPTION
Tests a fix to the Safari issue where the SVGs for the `SuisseIntl` font family appear to be corrupted for an unknown reason.

The screenshot below is one of the issue (prior to the fixes in this PR)
<img width="800" alt="scrn 2024-02-23 at 11 29 24 AM" src="https://github.com/data-preservation-programs/singularity-website/assets/3689720/886e58be-4201-43a8-8632-8d985029cc47">


***
🎟️ **Ticket** [AU-3212](https://www.notion.so/agencyundone/Safari-SVG-font-rendering-issue-df2ddca93ce6453ca2d6190d8097b374?pvs=4)